### PR TITLE
Feature apiv2 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ ENV/
 .project
 .pydevproject
 .settings/
+*~

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,8 @@
 from __future__ import (
     absolute_import,
     unicode_literals)
+
+# assertRaisesRegexp is deprecated in Python 3.7; patch newer API into older versions
+import unittest
+if not hasattr( unittest.TestCase, 'assertRaisesRegex' ):
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp

--- a/tests/zoomus/components/meeting/test_create.py
+++ b/tests/zoomus/components/meeting/test_create.py
@@ -42,15 +42,15 @@ class CreateV1TestCase(unittest.TestCase):
             )
 
     def test_requires_host_id(self):
-        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'host_id' must be set"):
             self.component.create()
 
     def test_requires_topic(self):
-        with self.assertRaisesRegexp(ValueError, "'topic' must be set"):
+        with self.assertRaisesRegex(ValueError, "'topic' must be set"):
             self.component.create(host_id='ID')
 
     def test_requires_type(self):
-        with self.assertRaisesRegexp(ValueError, "'type' must be set"):
+        with self.assertRaisesRegex(ValueError, "'type' must be set"):
             self.component.create(host_id='ID', topic='TOPIC')
 
     @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
@@ -96,7 +96,7 @@ class CreateV2TestCase(unittest.TestCase):
         )
 
     def test_requires_user_id(self):
-        with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'user_id' must be set"):
             self.component.create()
 
     @patch.object(components.base.BaseComponent, 'post_request', return_value=True)

--- a/tests/zoomus/components/meeting/test_create.py
+++ b/tests/zoomus/components/meeting/test_create.py
@@ -88,7 +88,7 @@ class CreateV2TestCase(unittest.TestCase):
 
         mock_post_request.assert_called_with(
             "/users/ID/meetings",
-            params={
+            data={
                 'user_id': 'ID',
                 'topic': 'TOPIC',
                 'type': 'TYPE'
@@ -108,7 +108,7 @@ class CreateV2TestCase(unittest.TestCase):
 
         mock_post_request.assert_called_with(
             "/users/ID/meetings",
-            params={
+            data={
                 'user_id': 'ID',
                 'start_time': util.date_to_str(start_time)
             }

--- a/tests/zoomus/components/meeting/test_delete.py
+++ b/tests/zoomus/components/meeting/test_delete.py
@@ -72,7 +72,7 @@ class DeleteV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.delete()
 
 

--- a/tests/zoomus/components/meeting/test_delete.py
+++ b/tests/zoomus/components/meeting/test_delete.py
@@ -66,9 +66,7 @@ class DeleteV2TestCase(unittest.TestCase):
         self.component.delete(id='ID')
         mock_delete_request.assert_called_with(
             "/meetings/ID",
-            params={
-                'id': 'ID',
-            }
+            params={}
         )
 
     def test_requires_id(self):

--- a/tests/zoomus/components/meeting/test_get.py
+++ b/tests/zoomus/components/meeting/test_get.py
@@ -67,7 +67,7 @@ class GetV2TestCase(unittest.TestCase):
         mock_get_request.assert_called_with("/meetings/ID", params={'id': 'ID'})
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.get()
 
 

--- a/tests/zoomus/components/meeting/test_list.py
+++ b/tests/zoomus/components/meeting/test_list.py
@@ -89,7 +89,7 @@ class ListV2TestCase(unittest.TestCase):
         )
 
     def test_requires_user_id(self):
-        with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'user_id' must be set"):
             self.component.list()
 
 

--- a/tests/zoomus/components/meeting/test_update.py
+++ b/tests/zoomus/components/meeting/test_update.py
@@ -80,7 +80,7 @@ class UpdateV2TestCase(unittest.TestCase):
 
         mock_post_request.assert_called_with(
             "/meetings/42",
-            params={
+            data={
                 'id': '42',
                 'foo': 'bar'
             }
@@ -97,7 +97,7 @@ class UpdateV2TestCase(unittest.TestCase):
         self.component.update(id='42', start_time=datetime(1969, 1, 1))
         mock_patch_request.assert_called_with(
             "/meetings/42",
-            params={
+            data={
                 'id': '42',
                 'start_time': '1969-01-01T00:00:00Z'
             }

--- a/tests/zoomus/components/recording/test_delete.py
+++ b/tests/zoomus/components/recording/test_delete.py
@@ -65,7 +65,7 @@ class DeleteV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'meeting_id' must be set"):
             self.component.delete()
 
 

--- a/tests/zoomus/components/recording/test_get.py
+++ b/tests/zoomus/components/recording/test_get.py
@@ -65,7 +65,7 @@ class GetV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'meeting_id' must be set"):
             self.component.get()
 
 

--- a/tests/zoomus/components/recording/test_list.py
+++ b/tests/zoomus/components/recording/test_list.py
@@ -91,7 +91,7 @@ class ListV2TestCase(unittest.TestCase):
         )
 
     def test_requires_user_id(self):
-        with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'user_id' must be set"):
             self.component.list()
 
     @patch.object(components.base.BaseComponent, 'get_request', return_value=True)

--- a/tests/zoomus/components/report/test_get_account_report.py
+++ b/tests/zoomus/components/report/test_get_account_report.py
@@ -102,11 +102,11 @@ class GetAccountReportV2TestCase(unittest.TestCase):
         )
 
     def test_requires_start_time(self):
-        with self.assertRaisesRegexp(ValueError, "'start_time' must be set"):
+        with self.assertRaisesRegex(ValueError, "'start_time' must be set"):
             self.component.get_account_report()
 
     def test_requires_end_time(self):
-        with self.assertRaisesRegexp(ValueError, "'end_time' must be set"):
+        with self.assertRaisesRegex(ValueError, "'end_time' must be set"):
             self.component.get_account_report(start_time=datetime.datetime.utcnow())
 
     @patch.object(components.base.BaseComponent, 'get_request', return_value=True)

--- a/tests/zoomus/components/report/test_get_user_report.py
+++ b/tests/zoomus/components/report/test_get_user_report.py
@@ -103,15 +103,15 @@ class GetUserReportV2TestCase(unittest.TestCase):
         )
 
     def test_requires_user_id(self):
-        with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'user_id' must be set"):
             self.component.get_user_report()
 
     def test_requires_start_time(self):
-        with self.assertRaisesRegexp(ValueError, "'start_time' must be set"):
+        with self.assertRaisesRegex(ValueError, "'start_time' must be set"):
             self.component.get_user_report(user_id='ID')
 
     def test_requires_end_time(self):
-        with self.assertRaisesRegexp(ValueError, "'end_time' must be set"):
+        with self.assertRaisesRegex(ValueError, "'end_time' must be set"):
             self.component.get_user_report(user_id='ID', start_time=datetime.datetime.utcnow())
 
     @patch.object(components.base.BaseComponent, 'get_request', return_value=True)

--- a/tests/zoomus/components/user/test_delete.py
+++ b/tests/zoomus/components/user/test_delete.py
@@ -65,7 +65,7 @@ class DeleteV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.delete()
 
 

--- a/tests/zoomus/components/user/test_get.py
+++ b/tests/zoomus/components/user/test_get.py
@@ -37,7 +37,7 @@ class GetV1TestCase(unittest.TestCase):
             )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.get()
 
 
@@ -63,7 +63,7 @@ class GetV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.get()
 
 

--- a/tests/zoomus/components/user/test_update.py
+++ b/tests/zoomus/components/user/test_update.py
@@ -65,7 +65,7 @@ class UpdateV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.update()
 
 

--- a/tests/zoomus/components/webinar/test_create.py
+++ b/tests/zoomus/components/webinar/test_create.py
@@ -39,11 +39,11 @@ class CreateV1TestCase(unittest.TestCase):
         )
 
     def test_requires_host_id(self):
-        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'host_id' must be set"):
             self.component.create()
 
     def test_requires_topic(self):
-        with self.assertRaisesRegexp(ValueError, "'topic' must be set"):
+        with self.assertRaisesRegex(ValueError, "'topic' must be set"):
             self.component.create(host_id='ID')
 
     @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
@@ -85,7 +85,7 @@ class CreateV2TestCase(unittest.TestCase):
         )
 
     def test_requires_user_id(self):
-        with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'user_id' must be set"):
             self.component.create()
 
 

--- a/tests/zoomus/components/webinar/test_create.py
+++ b/tests/zoomus/components/webinar/test_create.py
@@ -79,7 +79,7 @@ class CreateV2TestCase(unittest.TestCase):
 
         mock_post_request.assert_called_with(
             "/users/ID/webinars",
-            params={
+            data={
                 'user_id': 'ID',
             }
         )

--- a/tests/zoomus/components/webinar/test_delete.py
+++ b/tests/zoomus/components/webinar/test_delete.py
@@ -61,9 +61,7 @@ class DeleteV2TestCase(unittest.TestCase):
 
         mock_delete_request.assert_called_with(
             "/webinars/ID",
-            params={
-                'id': 'ID',
-            }
+            params={}
         )
 
     def test_requires_id(self):

--- a/tests/zoomus/components/webinar/test_delete.py
+++ b/tests/zoomus/components/webinar/test_delete.py
@@ -36,11 +36,11 @@ class DeleteV1TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.delete()
 
     def test_requires_host_id(self):
-        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'host_id' must be set"):
             self.component.delete(id='ID')
 
 
@@ -67,7 +67,7 @@ class DeleteV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.delete()
 
 

--- a/tests/zoomus/components/webinar/test_end.py
+++ b/tests/zoomus/components/webinar/test_end.py
@@ -36,11 +36,11 @@ class EndV1TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.end()
 
     def test_requires_host_id(self):
-        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'host_id' must be set"):
             self.component.end(id='ID')
 
 
@@ -67,7 +67,7 @@ class EndV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.end()
 
 

--- a/tests/zoomus/components/webinar/test_get.py
+++ b/tests/zoomus/components/webinar/test_get.py
@@ -36,11 +36,11 @@ class GetV1TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.get()
 
     def test_requires_host_id(self):
-        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'host_id' must be set"):
             self.component.get(id='ID')
 
 
@@ -67,7 +67,7 @@ class GetV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.get()
 
 

--- a/tests/zoomus/components/webinar/test_list.py
+++ b/tests/zoomus/components/webinar/test_list.py
@@ -38,7 +38,7 @@ class ListV1TestCase(unittest.TestCase):
         )
 
     def test_requires_host_id(self):
-        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'host_id' must be set"):
             self.component.list()
 
     @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
@@ -82,7 +82,7 @@ class ListV2TestCase(unittest.TestCase):
         )
 
     def test_requires_user_id(self):
-        with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'user_id' must be set"):
             self.component.list()
 
 

--- a/tests/zoomus/components/webinar/test_register.py
+++ b/tests/zoomus/components/webinar/test_register.py
@@ -43,19 +43,19 @@ class RegisterV1TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.register()
 
     def test_requires_email(self):
-        with self.assertRaisesRegexp(ValueError, "'email' must be set"):
+        with self.assertRaisesRegex(ValueError, "'email' must be set"):
             self.component.register(id='ID')
 
     def test_requires_first_name(self):
-        with self.assertRaisesRegexp(ValueError, "'first_name' must be set"):
+        with self.assertRaisesRegex(ValueError, "'first_name' must be set"):
             self.component.register(id='ID', email='foo@bar.com')
 
     def test_requires_last_name(self):
-        with self.assertRaisesRegexp(ValueError, "'last_name' must be set"):
+        with self.assertRaisesRegex(ValueError, "'last_name' must be set"):
             self.component.register(
                 id='ID', email='foo@bar.com', first_name='foo')
 
@@ -107,19 +107,19 @@ class RegisterV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.register()
 
     def test_requires_email(self):
-        with self.assertRaisesRegexp(ValueError, "'email' must be set"):
+        with self.assertRaisesRegex(ValueError, "'email' must be set"):
             self.component.register(id='ID')
 
     def test_requires_first_name(self):
-        with self.assertRaisesRegexp(ValueError, "'first_name' must be set"):
+        with self.assertRaisesRegex(ValueError, "'first_name' must be set"):
             self.component.register(id='ID', email='foo@bar.com')
 
     def test_requires_last_name(self):
-        with self.assertRaisesRegexp(ValueError, "'last_name' must be set"):
+        with self.assertRaisesRegex(ValueError, "'last_name' must be set"):
             self.component.register(
                 id='ID', email='foo@bar.com', first_name='foo')
 

--- a/tests/zoomus/components/webinar/test_update.py
+++ b/tests/zoomus/components/webinar/test_update.py
@@ -37,11 +37,11 @@ class UpdateV1TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.update()
 
     def test_requires_host_id(self):
-        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'host_id' must be set"):
             self.component.update(id='ID')
 
     @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
@@ -80,7 +80,7 @@ class UpdateV2TestCase(unittest.TestCase):
         )
 
     def test_requires_id(self):
-        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+        with self.assertRaisesRegex(ValueError, "'id' must be set"):
             self.component.update()
 
 

--- a/tests/zoomus/components/webinar/test_update.py
+++ b/tests/zoomus/components/webinar/test_update.py
@@ -74,7 +74,7 @@ class UpdateV2TestCase(unittest.TestCase):
 
         mock_patch_request.assert_called_with(
             "/webinars/ID",
-            params={
+            data={
                 'id': 'ID',
             }
         )

--- a/tests/zoomus/test_client.py
+++ b/tests/zoomus/test_client.py
@@ -30,7 +30,7 @@ class ZoomClientTestCase(unittest.TestCase):
         )
 
     def test_invalid_api_version_raises_error(self):
-        with self.assertRaisesRegexp(RuntimeError, "API version not supported: 42"):
+        with self.assertRaisesRegex(RuntimeError, "API version not supported: 42"):
             ZoomClient('KEY', 'SECRET', version=42)
 
     def test_init_sets_config_with_timeout(self):

--- a/tests/zoomus/test_util.py
+++ b/tests/zoomus/test_util.py
@@ -138,7 +138,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_post.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -155,7 +155,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_post.assert_called_with(
             client.url_for('endpoint'),
             params={'foo': 'bar'},
-            data=None,
+            json=None,
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -172,7 +172,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_post.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            json={'foo': 'bar'},
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -189,7 +189,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_post.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            json=json.dumps({'foo': 'bar'}),
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -206,7 +206,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_post.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers={'foo': 'bar'},
             cookies=None,
             timeout=client.timeout
@@ -223,7 +223,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_post.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers=None,
             cookies={'foo': 'bar'},
             timeout=client.timeout
@@ -240,7 +240,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_patch.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -257,7 +257,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_patch.assert_called_with(
             client.url_for('endpoint'),
             params={'foo': 'bar'},
-            data=None,
+            json=None,
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -274,7 +274,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_patch.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            json={'foo': 'bar'},
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -291,7 +291,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_patch.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            json=json.dumps({'foo': 'bar'}),
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -308,7 +308,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_patch.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers={'foo': 'bar'},
             cookies=None,
             timeout=client.timeout
@@ -325,7 +325,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_patch.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers=None,
             cookies={'foo': 'bar'},
             timeout=client.timeout
@@ -342,7 +342,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_delete.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -359,7 +359,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_delete.assert_called_with(
             client.url_for('endpoint'),
             params={'foo': 'bar'},
-            data=None,
+            json=None,
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -376,7 +376,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_delete.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            json={'foo': 'bar'},
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -393,7 +393,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_delete.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            json=json.dumps({'foo': 'bar'}),
             headers=None,
             cookies=None,
             timeout=client.timeout
@@ -410,7 +410,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_delete.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers={'foo': 'bar'},
             cookies=None,
             timeout=client.timeout
@@ -427,7 +427,7 @@ class ApiClientTestCase(unittest.TestCase):
         mocked_delete.assert_called_with(
             client.url_for('endpoint'),
             params=None,
-            data=None,
+            json=None,
             headers=None,
             cookies={'foo': 'bar'},
             timeout=client.timeout

--- a/zoomus/components/meeting.py
+++ b/zoomus/components/meeting.py
@@ -54,7 +54,7 @@ class MeetingComponentV2(base.BaseComponent):
             kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
         return self.post_request(
             "/users/{}/meetings".format(kwargs.get('user_id')),
-            params=kwargs)
+            data=kwargs)
 
     def get(self, **kwargs):
         util.require_keys(kwargs, 'id')
@@ -68,7 +68,7 @@ class MeetingComponentV2(base.BaseComponent):
             kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
         return self.patch_request(
             "/meetings/{}".format(kwargs.get('id')),
-            params=kwargs)
+            data=kwargs)
 
     def delete(self, **kwargs):
         util.require_keys(kwargs, 'id')

--- a/zoomus/components/meeting.py
+++ b/zoomus/components/meeting.py
@@ -72,6 +72,7 @@ class MeetingComponentV2(base.BaseComponent):
 
     def delete(self, **kwargs):
         util.require_keys(kwargs, 'id')
+        meetingId = kwargs.pop('id')
         return self.delete_request(
-            "/meetings/{}".format(kwargs.get('id')),
+            "/meetings/{}".format(meetingId),
             params=kwargs)

--- a/zoomus/components/webinar.py
+++ b/zoomus/components/webinar.py
@@ -63,20 +63,25 @@ class WebinarComponentV2(base.BaseComponent):
 
     def create(self, **kwargs):
         util.require_keys(kwargs, 'user_id')
+        if kwargs.get('start_time'):
+            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
         return self.post_request(
             "/users/{}/webinars".format(kwargs.get('user_id')),
-            params=kwargs)
+            data=kwargs)
 
     def update(self, **kwargs):
         util.require_keys(kwargs, 'id')
+        if kwargs.get('start_time'):
+            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
         return self.patch_request(
             "/webinars/{}".format(kwargs.get('id')),
-            params=kwargs)
+            data=kwargs)
 
     def delete(self, **kwargs):
         util.require_keys(kwargs, 'id')
+        meetingId = kwargs.pop('id')
         return self.delete_request(
-            "/webinars/{}".format(kwargs.get('id')),
+            "/webinars/{}".format(meetingId),
             params=kwargs)
 
     def end(self, **kwargs):

--- a/zoomus/util.py
+++ b/zoomus/util.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import contextlib
-import json
 import requests
 import time
 import jwt

--- a/zoomus/util.py
+++ b/zoomus/util.py
@@ -90,20 +90,17 @@ class ApiClient(object):
 
         :param endpoint: The endpoint
         :param params: The URL parameters
-        :param data: The data (either as a dict or dumped JSON string) to
-                     include with the POST
+        :param data: The data as a dict to include with the POST
         :param headers: request headers
         :param cookies: request cookies
         :return: The :class:``requests.Response`` object for this request
         """
-        if data and not is_str_type(data):
-            data = json.dumps(data)
         if headers is None and self.config.get('version') == API_VERSION_2:
             headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
         return requests.post(
             self.url_for(endpoint),
             params=params,
-            data=data,
+            json=data,
             headers=headers,
             cookies=cookies,
             timeout=self.timeout)
@@ -114,20 +111,17 @@ class ApiClient(object):
 
         :param endpoint: The endpoint
         :param params: The URL parameters
-        :param data: The data (either as a dict or dumped JSON string) to
-                     include with the PATCH
+        :param data: The data as a dict to include with the PATCH
         :param headers: request headers
         :param cookies: request cookies
         :return: The :class:``requests.Response`` object for this request
         """
-        if data and not is_str_type(data):
-            data = json.dumps(data)
         if headers is None and self.config.get('version') == API_VERSION_2:
             headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
         return requests.patch(
             self.url_for(endpoint),
             params=params,
-            data=data,
+            json=data,
             headers=headers,
             cookies=cookies,
             timeout=self.timeout)
@@ -138,20 +132,17 @@ class ApiClient(object):
 
         :param endpoint: The endpoint
         :param params: The URL parameters
-        :param data: The data (either as a dict or dumped JSON string) to
-                     include with the DELETE
+        :param data: The data as a dict to include with the DELETE
         :param headers: request headers
         :param cookies: request cookies
         :return: The :class:``requests.Response`` object for this request
         """
-        if data and not is_str_type(data):
-            data = json.dumps(data)
         if headers is None and self.config.get('version') == API_VERSION_2:
             headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
         return requests.delete(
             self.url_for(endpoint),
             params=params,
-            data=data,
+            json=data,
             headers=headers,
             cookies=cookies,
             timeout=self.timeout)
@@ -162,20 +153,17 @@ class ApiClient(object):
 
         :param endpoint: The endpoint
         :param params: The URL paramaters
-        :param data: The data (either as a dict or dumped JSON string) to
-                     include with the PUT
+        :param data: The data as a dict to include with the PUT
         :param headers: request headers
         :param cookies: request cookies
         :return: The :class:``requests.Response`` object for this request
         """
-        if data and not is_str_type(data):
-            data = json.dumps(data)
         if headers is None and self.config.get('version') == API_VERSION_2:
             headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
         return requests.put(
             self.url_for(endpoint),
             params=params,
-            data=data,
+            json=data,
             headers=headers,
             cookies=cookies,
             timeout=self.timeout)

--- a/zoomus/util.py
+++ b/zoomus/util.py
@@ -185,7 +185,7 @@ class ApiClient(object):
 def ignored(*exceptions):
     """Simple context manager to ignore expected Exceptions
 
-    :param \*exceptions: The exceptions to safely ignore
+    :param exceptions: The exceptions to safely ignore
     """
     try:
         yield


### PR DESCRIPTION
o Fix up unit test, string literal warnings, etc. for Python 3.7
o Use request's json=... instead of data=... w/ manually JSON conversion